### PR TITLE
Do not add commands to "See also" box multiple times

### DIFF
--- a/tldr-viewer/DetailPlatformViewModel.swift
+++ b/tldr-viewer/DetailPlatformViewModel.swift
@@ -138,6 +138,10 @@ class DetailPlatformViewModel {
         
         for codeBlockAndRange in codeBlocksAndRanges {
             let codeBlock = codeBlockAndRange.substring
+            if seeAlsoCommands.contains(where: { $0.name == codeBlock }) {
+                // Command has already been collected
+                continue
+            }
             
             // check this codeblock doesn't reference the current command -
             // we don't want to generate hyperlinks to ourself


### PR DESCRIPTION
As an example, the `fd` command currently contains two references to the `find` command in the **See also** box. See:

![find-twice](https://user-images.githubusercontent.com/16365760/67124421-ccb05a80-f1f2-11e9-9811-c8f25f5e1913.png)