### PR TITLE
Style summary text in "See also"

### DIFF
--- a/tldr-viewer/DetailPlatformViewModel.swift
+++ b/tldr-viewer/DetailPlatformViewModel.swift
@@ -181,7 +181,8 @@ class DetailPlatformViewModel {
                 
                 if let seeAlsoCommandVariant = seeAlsoCommandVariant {
                     let summary = seeAlsoCommandVariant.summary()
-                    seeAlsoHTML += "<dt><a href=\"\(seeAlsoCommandName)\">\(seeAlsoCommandName)</a></dt><dd>\(summary)</dd>"
+                    let htmlSummary = (try? Down(markdownString: summary).toHTML()) ?? summary
+                    seeAlsoHTML += "<dt><a href=\"\(seeAlsoCommandName)\">\(seeAlsoCommandName)</a></dt><dd>\(htmlSummary)</dd>"
                 }
             }
             seeAlsoHTML += "</dl></div>"


### PR DESCRIPTION
The **See also** section for `apm` looks like

![no-style-in-see-also](https://user-images.githubusercontent.com/16365760/67147264-b8706a00-f293-11e9-87af-2f5976daa726.png)

No styling is applied to the summary text. Code snippets are shown as plain Markdown and URLs are not displayed at all.